### PR TITLE
Suggestion for #106 - create database javabg

### DIFF
--- a/src/main/java/site/app/Application.java
+++ b/src/main/java/site/app/Application.java
@@ -149,10 +149,6 @@ public class Application  extends SpringBootServletInitializer {
     @Bean
     public DataSource primaryDataSource() {
 
-        System.out.println("MIHAIL: "+user);
-        System.out.println("MIHAIL: "+password);
-        System.out.println("MIHAIL: "+dataSourceUrl);
-        System.out.println("MIHAIL: "+driverClassName);
         Properties dsProps = new Properties();
         dsProps.setProperty("url", dataSourceUrl);
         dsProps.setProperty("user", user);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/javabg?autoReconnect=true&amp;useUnicode=true&amp;characterEncoding=UTF-8&amp;connectionCollation=utf8_general_ci&amp;characterSetResults=utf8&amp;autoDeserialize=true&useConfigs=maxPerformance
+spring.datasource.url=jdbc:mysql://localhost:3306/javabg?autoReconnect=true&createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=UTF-8&connectionCollation=utf8_general_ci&characterSetResults=utf8&autoDeserialize=true&useConfigs=maxPerformance
 spring.datasource.username=root
 spring.datasource.password=admin
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/javabg?autoReconnect=true&createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=UTF-8&connectionCollation=utf8_general_ci&characterSetResults=utf8&autoDeserialize=true&useConfigs=maxPerformance
+spring.datasource.url=jdbc:mysql://localhost:3306/javabg?autoReconnect=true&createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=UTF-8&connectionCollation=utf8_general_ci&characterSetResults=utf8&autoDeserialize=true
 spring.datasource.username=root
 spring.datasource.password=admin
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver

--- a/src/test/java/site/controller/SessionControllerTest.java
+++ b/src/test/java/site/controller/SessionControllerTest.java
@@ -117,8 +117,8 @@ public class SessionControllerTest {
 
         Session session = sessions.get(1);
         assertThat(session.getSubmission().getTitle(), is(forgeSubmission.getTitle()));
-        assertThat(session.getStartTime(), is(new DateTime().withMonthOfYear(5).withDayOfMonth(26).withHourOfDay(10).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
-        assertThat(session.getEndTime(), is(new DateTime().withMonthOfYear(5).withDayOfMonth(26).withHourOfDay(11).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
+        assertThat(session.getStartTime(), is(new DateTime().withYear(2017).withMonthOfYear(5).withDayOfMonth(26).withHourOfDay(10).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
+        assertThat(session.getEndTime(), is(new DateTime().withYear(2017).withMonthOfYear(5).withDayOfMonth(26).withHourOfDay(11).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
         assertThat(session.getHall().getName(), is(betaHall.getName()));
         assertTrue(session.getTitle().startsWith(session.getSubmission().getTitle()) &&
                 session.getTitle().endsWith(session.getSubmission().getSpeaker().getLastName()));
@@ -141,8 +141,8 @@ public class SessionControllerTest {
         Session session = sessions.get(1);
         assertNull(session.getSubmission());
         assertThat(session.getTitle(), is("Coffee break"));
-        assertThat(session.getStartTime(), is(new DateTime().withMonthOfYear(5).withDayOfMonth(26).withHourOfDay(10).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
-        assertThat(session.getEndTime(), is(new DateTime().withMonthOfYear(5).withDayOfMonth(26).withHourOfDay(11).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
+        assertThat(session.getStartTime(), is(new DateTime().withYear(2017).withMonthOfYear(5).withDayOfMonth(26).withHourOfDay(10).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
+        assertThat(session.getEndTime(), is(new DateTime().withYear(2017).withMonthOfYear(5).withDayOfMonth(26).withHourOfDay(11).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
         assertNull(session.getHall());
     }
 
@@ -163,8 +163,8 @@ public class SessionControllerTest {
 
         Session session = sessions.get(0);
         assertThat(session.getSubmission().getTitle(), is(bootSubmission.getTitle()));
-        assertThat(session.getStartTime(), is(new DateTime().withMonthOfYear(5).withDayOfMonth(27).withHourOfDay(10).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
-        assertThat(session.getEndTime(), is(new DateTime().withMonthOfYear(5).withDayOfMonth(27).withHourOfDay(11).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
+        assertThat(session.getStartTime(), is(new DateTime().withYear(2017).withMonthOfYear(5).withDayOfMonth(27).withHourOfDay(10).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
+        assertThat(session.getEndTime(), is(new DateTime().withYear(2017).withMonthOfYear(5).withDayOfMonth(27).withHourOfDay(11).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
         assertThat(session.getHall().getName(), is(betaHall.getName()));
     }
 
@@ -184,8 +184,8 @@ public class SessionControllerTest {
 
         Session session = sessions.get(0);
         assertNull(session.getSubmission());
-        assertThat(session.getStartTime(), is(new DateTime().withMonthOfYear(5).withDayOfMonth(27).withHourOfDay(10).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
-        assertThat(session.getEndTime(), is(new DateTime().withMonthOfYear(5).withDayOfMonth(27).withHourOfDay(11).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
+        assertThat(session.getStartTime(), is(new DateTime().withYear(2017).withMonthOfYear(5).withDayOfMonth(27).withHourOfDay(10).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
+        assertThat(session.getEndTime(), is(new DateTime().withYear(2017).withMonthOfYear(5).withDayOfMonth(27).withHourOfDay(11).withMinuteOfHour(15).withSecondOfMinute(0).withMillisOfSecond(0)));
         assertNull(session.getHall());
         assertThat(session.getTitle(), is("Opening"));
     }


### PR DESCRIPTION
Actually ConnectorJ can do that with `createDatabaseIfNotExist` property. [Docs](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html):

> Creates the database given in the URL if it doesn't yet exist. Assumes the configured user has permissions to create databases.
> 
> Default: false
> 
> Since version: 3.1.9

In this PR you can additionally see:

- remove of the `System.out` that prints the DB password in the standard out :)
- fixing few test so that all tests can pass