### PR TITLE
Fixed some google fonts URLs - They must be served by https request

### DIFF
--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -27,9 +27,9 @@
 
 
 
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800);
-@import url(http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic);
-@import url(http://fonts.googleapis.com/css?family=Raleway:400,300,700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800);
+@import url(https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic);
+@import url(https://fonts.googleapis.com/css?family=Raleway:400,300,700);
 
 
 


### PR DESCRIPTION
The website is using SSL, so every external resource should be accessed via https.

![mixedcontent-googlefonts](https://user-images.githubusercontent.com/19496422/38406716-119e78ee-397f-11e8-9700-586cb67742f5.jpg)
