### PR TITLE
Introduce invoice detail as detail for invoice data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target/
 .idea
 .forge_settings
 .DS_Store
+/.metadata/

--- a/src/main/java/site/controller/AdminInvoiceController.java
+++ b/src/main/java/site/controller/AdminInvoiceController.java
@@ -9,14 +9,16 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import site.controller.invoice.InvoiceData;
-import site.controller.invoice.InvoiceExporter;
+import site.controller.invoice.*;
 import site.facade.MailService;
 import site.facade.RegistrantService;
 import site.model.Registrant;
 
 import javax.transaction.Transactional;
 import javax.validation.Valid;
+
+import static site.controller.TicketsController.*;
+import static site.controller.invoice.InvoiceLanguage.*;
 
 /**
  * @author Ivan St. Ivanov
@@ -64,12 +66,13 @@ public class AdminInvoiceController {
         invoiceData.setInvoiceNumber(String.valueOf(registrant.getRealInvoiceNumber()));
 
         try {
-            byte[] invoice = invoiceExporter.exportInvoice(invoiceData, registrant.isCompany());
+            byte[] invoice = invoiceExporter.exportInvoice(invoiceData, registrant.isCompany(), BG);
             mailFacade.sendInvoice(registrant.getEmail(), "jPrime.io original invoice",
                     "Please find attached the invoice for the conference passes that you purchased.",
-                    invoice, TicketsController.generatePdfFilename(registrant, invoiceData.getSinglePriceWithVAT()));
+                    invoice, generatePdfFilename(registrant, invoiceData.getTotalPriceWithVAT()));
             mailFacade.sendInvoice("conference@jprime.io", "jPrime.io invoice",
-                    "The attached invoice was sent to " + registrant.getEmail(), invoice, TicketsController.generatePdfFilename(registrant, invoiceData.getSinglePriceWithVAT()));
+                    "The attached invoice was sent to " + registrant.getEmail(), invoice,
+                generatePdfFilename(registrant, invoiceData.getTotalPriceWithVAT()));
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/site/controller/AdminInvoiceController.java
+++ b/src/main/java/site/controller/AdminInvoiceController.java
@@ -69,10 +69,19 @@ public class AdminInvoiceController {
         }
 
         Registrant  registrant = registrantFacade.findById(modelInvoiceData.getRegistrantId());
+
+        registrantFacade.setRegistrantPaid(registrant);
+
         InvoiceData invoiceData = InvoiceData.fromRegistrant(registrant);
+        // Copy data from model into actual invoice data bean
+        invoiceData.setClient(modelInvoiceData.getClient());
+        invoiceData.setClientAddress(modelInvoiceData.getClientAddress());
+        invoiceData.setClientEIK(modelInvoiceData.getClientEIK());
+        invoiceData.setClientVAT(modelInvoiceData.getClientVAT());
+        invoiceData.setMol(modelInvoiceData.getMol());
+        invoiceData.setInvoiceDate(modelInvoiceData.getInvoiceDate());
         invoiceData.setSinglePriceWithVAT(modelInvoiceData.getSinglePriceWithVAT());
         invoiceData.setDescription(modelInvoiceData.getDescription());
-        registrantFacade.setRegistrantPaid(registrant);
 
         invoiceData.setInvoiceType(InvoiceData.ORIGINAL_BG);
         if (invoiceData.getInvoiceNumber().equals("0")) {

--- a/src/main/java/site/controller/TicketsController.java
+++ b/src/main/java/site/controller/TicketsController.java
@@ -1,5 +1,9 @@
 package site.controller;
 
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
@@ -12,8 +16,7 @@ import javax.validation.Valid;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.*;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -21,14 +24,16 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-import site.controller.invoice.InvoiceData;
-import site.controller.invoice.InvoiceExporter;
+import site.controller.invoice.*;
 import site.facade.MailService;
 import site.facade.RegistrantService;
 import site.facade.UserService;
 import site.model.Registrant;
 import site.model.Visitor;
 import site.model.VisitorStatus;
+
+import static org.springframework.util.StringUtils.*;
+import static site.controller.invoice.InvoiceLanguage.*;
 
 /**
  * @author Mihail
@@ -58,6 +63,12 @@ public class TicketsController {
     @Qualifier(RegistrantService.NAME)
     private RegistrantService registrantFacade;
 
+    @Value("${save.invoice.on.email.failure:false}")
+    private boolean saveInvoiceOnFailure;
+
+    @Value("${save.invoice.path.to.save:/tmp    }")
+    private String pathToSave;
+
     @RequestMapping(value = "/tickets", method = RequestMethod.GET)
     public String goToRegisterPage(Model model) {
         model.addAttribute("tags", userFacade.findAllTags());
@@ -82,7 +93,7 @@ public class TicketsController {
 		}
 
         //check empty users, server side validation
-        List<Visitor> toBeRemoved = registrant.getVisitors().stream().filter(v -> v.getEmail() == null || v.getEmail().isEmpty() || v.getName() == null || v.getName().isEmpty()).collect(Collectors.toList());
+        List<Visitor> toBeRemoved = registrant.getVisitors().stream().filter(v -> isEmpty(v.getEmail()) || isEmpty(v.getName())).collect(Collectors.toList());
         registrant.getVisitors().removeAll(toBeRemoved);
         registrant.getVisitors().forEach(visitor -> visitor.setStatus(VisitorStatus.REQUESTING));
 
@@ -97,8 +108,8 @@ public class TicketsController {
 
         InvoiceData invoiceData = buildInvoiceData(savedRegistrant);
 
-        byte[] pdf = invoiceExporter.exportInvoice(invoiceData, registrant.isCompany());
-        sendPDF(savedRegistrant, generatePdfFilename(registrant, invoiceData.getSinglePriceWithVAT()), pdf);
+        byte[] pdf = invoiceExporter.exportInvoice(invoiceData, registrant.isCompany(), BG);
+        sendPDF(savedRegistrant, generatePdfFilename(registrant, invoiceData.getTotalPriceWithVAT()), pdf);
         return result("ok", model);
     }
 
@@ -111,7 +122,7 @@ public class TicketsController {
 
     private InvoiceData buildInvoiceData(Registrant registrant) {
         InvoiceData invoiceData = InvoiceData.fromRegistrant(registrant);
-        if(registrant.getPaymentType().equals(Registrant.PaymentType.BANK_TRANSFER)) {
+        if(registrant.getPaymentType() == Registrant.PaymentType.BANK_TRANSFER) {
             invoiceData.setInvoiceType(InvoiceData.PROFORMA_BG);//currently hardcoded
             invoiceData.setInvoiceNumber(String.valueOf(registrant.getProformaInvoiceNumber()));
         } else {
@@ -130,6 +141,13 @@ public class TicketsController {
             mailFacade.sendInvoice("conference@jprime.io", "jPrime.io invoice",
                     "We got some registrations: " + registrations, pdfContent, pdfFilename);
         } catch (Exception e) {
+            if (saveInvoiceOnFailure) {
+                try {
+                    Files.write(Paths.get(pathToSave, pdfFilename), pdfContent);
+                } catch (IOException e1) {
+                    logger.error("Could not save confirmation email", e);
+                }
+            }
             logger.error("Could not send confirmation email", e);
         }
     }
@@ -139,14 +157,14 @@ public class TicketsController {
         return TICKETS_RESULT_JSP;
     }
 
-    public static String generatePdfFilename(Registrant registrant, double singlePriceWithVAT) {
+    public static String generatePdfFilename(Registrant registrant, BigDecimal totalPriceWithVAT) {
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy.MM.dd");
         String date = dateFormat.format(Calendar.getInstance().getTime());
 
         if(registrant.getRealInvoiceNumber() != 0) {
-            return date+", "+registrant.getRealInvoiceNumber()+", "+registrant.getName()+", "+registrant.getVisitors().size()+"tickets, "+(registrant.getVisitors().size()*singlePriceWithVAT)+".pdf";
+            return date+", "+registrant.getRealInvoiceNumber()+", "+registrant.getName()+", "+registrant.getVisitors().size()+"tickets, "+(totalPriceWithVAT)+".pdf";
         } else {
-            return "P "+date+", "+registrant.getProformaInvoiceNumber()+", "+registrant.getName()+", "+registrant.getVisitors().size()+"tickets, "+(registrant.getVisitors().size()*singlePriceWithVAT)+".pdf";
+            return "P "+date+", "+registrant.getProformaInvoiceNumber()+", "+registrant.getName()+", "+registrant.getVisitors().size()+"tickets, "+(totalPriceWithVAT)+".pdf";
         }
     }
 }

--- a/src/main/java/site/controller/TicketsController.java
+++ b/src/main/java/site/controller/TicketsController.java
@@ -66,7 +66,7 @@ public class TicketsController {
     @Value("${save.invoice.on.email.failure:false}")
     private boolean saveInvoiceOnFailure;
 
-    @Value("${save.invoice.path.to.save:/tmp    }")
+    @Value("${save.invoice.path.to.save:/tmp}")
     private String pathToSave;
 
     @RequestMapping(value = "/tickets", method = RequestMethod.GET)

--- a/src/main/java/site/controller/invoice/InvoiceData.java
+++ b/src/main/java/site/controller/invoice/InvoiceData.java
@@ -1,14 +1,13 @@
 package site.controller.invoice;
 
-import site.config.Globals;
-import site.model.Registrant;
-import site.model.Visitor;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+
+import site.config.Globals;
+import site.model.Registrant;
 
 /**
  * DTO for the PDF
@@ -38,6 +37,9 @@ public class InvoiceData {
     private String paymentType;
     private Long registrantId;
     private List<InvoiceDetail> invoiceDetails = new ArrayList<>();
+    // Used to store data from model
+    private Double singlePriceWithVAT;
+    private String description;
 
     public BigDecimal getTotalPrice() {
         return invoiceDetails.stream()
@@ -171,5 +173,29 @@ public class InvoiceData {
 
     public List<InvoiceDetail> getInvoiceDetails() {
         return invoiceDetails;
+    }
+
+    public Double getSinglePriceWithVAT() {
+        return invoiceDetails.isEmpty() ? singlePriceWithVAT : invoiceDetails.get(0).getSinglePriceWithVAT().doubleValue();
+    }
+
+    public void setSinglePriceWithVAT(Double singlePriceWithVAT) {
+        if (invoiceDetails.isEmpty()) {
+            this.singlePriceWithVAT = singlePriceWithVAT;
+        } else {
+            invoiceDetails.get(0).setSinglePriceWithVAT(singlePriceWithVAT);
+        }
+    }
+
+    public String getDescription() {
+        return invoiceDetails.isEmpty() ? description : invoiceDetails.get(0).getDescription();
+    }
+
+    public void setDescription(String description) {
+        if (invoiceDetails.isEmpty()) {
+            this.description = description;
+        } else {
+            invoiceDetails.get(0).setDescription(description);
+        }
     }
 }

--- a/src/main/java/site/controller/invoice/InvoiceDetail.java
+++ b/src/main/java/site/controller/invoice/InvoiceDetail.java
@@ -1,0 +1,74 @@
+package site.controller.invoice;
+
+import java.math.BigDecimal;
+
+import static java.math.RoundingMode.HALF_EVEN;
+import static site.controller.invoice.InvoiceData.*;
+
+public class InvoiceDetail {
+
+    private Integer idx;
+
+    private BigDecimal singlePriceWithVAT = DEFAULT_TICKET_PRICE;
+    private Integer passQty;
+    private String description = DEFAULT_DESCRIPTION_BG;
+    public InvoiceDetail(Integer passQty) {
+        this.passQty = passQty;
+    }
+
+    public InvoiceDetail(BigDecimal singlePriceWithVAT, Integer passQty, String description) {
+        this.singlePriceWithVAT = singlePriceWithVAT;
+        this.passQty = passQty;
+        this.description = description;
+    }
+
+    public Integer getIdx() {
+        return idx;
+    }
+
+    public void setIdx(Integer idx) {
+        this.idx = idx;
+    }
+
+    public Integer getPassQty() {
+        return passQty;
+    }
+
+    public void setPassQty(Integer passQty) {
+        this.passQty = passQty;
+    }
+
+    public BigDecimal getSinglePriceWithVAT() {
+        return singlePriceWithVAT;
+    }
+
+    public void setSinglePriceWithVAT(double singlePriceWithVAT) {
+        this.singlePriceWithVAT = BigDecimal.valueOf(singlePriceWithVAT);
+    }
+
+    public void setSinglePriceWithVAT(BigDecimal singlePriceWithVAT) {
+        this.singlePriceWithVAT = singlePriceWithVAT;
+    }
+
+    /**
+     * Calculates price for single item without VAT
+     * @return
+     */
+    public BigDecimal getPrice() {
+        return getTotalPrice().divide(BigDecimal.valueOf(passQty), 2, HALF_EVEN);
+    }
+
+    public BigDecimal getTotalPrice() {
+        return singlePriceWithVAT.multiply(BigDecimal.valueOf(passQty))
+                                 .divide(VAT_DECREASE_RATIO, 2, HALF_EVEN);
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/site/controller/invoice/InvoiceExporter.java
+++ b/src/main/java/site/controller/invoice/InvoiceExporter.java
@@ -9,14 +9,15 @@ import org.springframework.stereotype.Service;
 import site.config.Globals;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+
+import static org.apache.commons.beanutils.PropertyUtils.*;
+import static site.controller.invoice.InvoiceData.*;
+import static site.controller.invoice.InvoiceLanguage.*;
 
 /**
  * Created by mitia on 10.04.15.
@@ -24,41 +25,61 @@ import java.util.Map;
 @Service
 public class InvoiceExporter {
 
-
-    public byte[] exportInvoice(InvoiceData data, boolean isCompany) throws Exception{
-
-
-        InputStream reportTemplate = null;
-        if (isCompany) {
-            reportTemplate = getClass().getResourceAsStream("/invoice/invoice_company_template_bg.jrxml");
-        } else {
-            reportTemplate = getClass().getResourceAsStream("/invoice/invoice_individual_template_bg.jrxml");
+    public byte[] exportInvoice(InvoiceData data, boolean isCompany, InvoiceLanguage language)
+        throws Exception {
+        String resourceName = null;
+        switch (language) {
+            case EN:
+                if (isCompany) {
+                    resourceName = "/invoice/invoice_company_template.jrxml";
+                } else {
+                    resourceName = "/invoice/invoice_individual_template.jrxml";
+                }
+                break;
+            case BG:
+                if (isCompany) {
+                    resourceName = "/invoice/invoice_company_template_bg.jrxml";
+                } else {
+                    resourceName = "/invoice/invoice_individual_template_bg.jrxml";
+                }
         }
+
+        InputStream reportTemplate = getClass().getResourceAsStream(resourceName);
         ByteArrayOutputStream result = new ByteArrayOutputStream();
 
-        ArrayList<InvoiceData> exportList = new ArrayList<>();
         // device with some new functionality
-        exportList.add(data);
-        JRBeanCollectionDataSource beanColDataSource = new JRBeanCollectionDataSource(
-                exportList);
+        List<InvoiceDetail> exportList = new ArrayList<>(data.getInvoiceDetails());
+        JRBeanCollectionDataSource beanColDataSource = new JRBeanCollectionDataSource(exportList);
+
+        JasperDesign jasperDesign = JRXmlLoader.load(reportTemplate);
+        JasperReport jasperReport = JasperCompileManager.compileReport(jasperDesign);
+
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("jprime.year", Globals.CURRENT_BRANCH.toString());
 
-        JasperDesign jasperDesign = JRXmlLoader.load(reportTemplate);
-        JasperReport jasperReport = JasperCompileManager
-                .compileReport(jasperDesign);
-        JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport,
-                parameters, beanColDataSource);
+        // Fill in other parameters that have matching properties in invoice data.
+        Arrays.stream(jasperReport.getParameters()).forEach(p -> {
+            try {
+                parameters.put(p.getName(), getProperty(data, p.getName()));
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                // this should not happen but any way print exception just in case.
+                e.printStackTrace();
+            } catch (NoSuchMethodException e) {
+                // This exception happens when we are asked for property that is not part of our invoice data.
+            }
+        });
+
+        JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, parameters, beanColDataSource);
 
         JRPdfExporter pdfExporter = new JRPdfExporter();
         pdfExporter.setParameter(JRExporterParameter.CHARACTER_ENCODING, "UTF-8");
-        pdfExporter
-                .setParameter(JRExporterParameter.JASPER_PRINT, jasperPrint);
+        pdfExporter.setParameter(JRExporterParameter.JASPER_PRINT, jasperPrint);
         pdfExporter.setParameter(JRExporterParameter.OUTPUT_STREAM, result);
         pdfExporter.exportReport();
 
         return result.toByteArray();
     }
+
     //demonstration purposes only!
     public static void main(String[] args) throws Exception {
         InvoiceData data = new InvoiceData();
@@ -69,11 +90,11 @@ public class InvoiceExporter {
         data.setClientEIK("2464387775");
         data.setClientVAT("BG2464387775");
         data.setMol("fda");
-        data.setPassQty(5);
         data.setInvoiceType("Проформа");
         data.setPaymentType("пеймънт");
-//        data.setPrice(55.5);
+        data.addInvoiceDetail(new InvoiceDetail(STUDENT_TICKET_PRICE, 3, DEFAULT_DESCRIPTION_BG));
+        data.addInvoiceDetail(new InvoiceDetail(DEFAULT_TICKET_PRICE, 3, DEFAULT_DESCRIPTION_BG));
 
-        Files.write(Paths.get("/tmp/result.pdf"), new InvoiceExporter().exportInvoice(data, false));
+        Files.write(Paths.get("/tmp/result.pdf"), new InvoiceExporter().exportInvoice(data, true, EN));
     }
 }

--- a/src/main/java/site/controller/invoice/InvoiceLanguage.java
+++ b/src/main/java/site/controller/invoice/InvoiceLanguage.java
@@ -1,0 +1,5 @@
+package site.controller.invoice;
+
+public enum InvoiceLanguage {
+    EN, BG
+}

--- a/src/main/java/site/facade/RegistrantService.java
+++ b/src/main/java/site/facade/RegistrantService.java
@@ -44,7 +44,7 @@ public class RegistrantService {
     /** Complicated */
     public synchronized Registrant save(Registrant registrant) {
 
-        if(registrant.getPaymentType().equals(Registrant.PaymentType.BANK_TRANSFER)) {
+        if(registrant.getPaymentType() == Registrant.PaymentType.BANK_TRANSFER) {
             long counter = getProformaInvoiceNumber();
             registrant.setProformaInvoiceNumber(counter);
         } else {
@@ -57,7 +57,6 @@ public class RegistrantService {
             if(registrant.getEpayResponse() != null && registrant.getRealInvoiceNumber() == 0) {
                 generateInvoiceNumber(registrant);
             }
-
         }
         //todo: mihail this is not optimal, but for now it works
         for(Visitor visitor:registrant.getVisitors()) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,4 +62,6 @@ site.reset.password.token.duration.hours=2
 spring.servlet.multipart.max-file-size = 20MB
 spring.servlet.multipart.max-request-size = 20MB
 
+#save.invoice.on.email.failure=true
+#save.invoice.path.to.save=/tmp
 

--- a/src/main/resources/invoice/invoice_company_template.jrxml
+++ b/src/main/resources/invoice/invoice_company_template.jrxml
@@ -4,23 +4,25 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<parameter name="jprime.year" class="java.lang.String" isForPrompting="false"/>
-	<field name="invoiceDate" class="java.lang.String"/>
-	<field name="invoiceNumber" class="java.lang.String"/>
-	<field name="client" class="java.lang.String"/>
-	<field name="clientAddress" class="java.lang.String"/>
-	<field name="clientVAT" class="java.lang.String"/>
-	<field name="clientEIK" class="java.lang.String"/>
+	<parameter name="invoiceDate" class="java.lang.String"/>
+	<parameter name="invoiceNumber" class="java.lang.String"/>
+	<parameter name="client" class="java.lang.String"/>
+	<parameter name="clientAddress" class="java.lang.String"/>
+	<parameter name="clientVAT" class="java.lang.String"/>
+	<parameter name="clientEIK" class="java.lang.String"/>
+	<parameter name="mol" class="java.lang.String"/>
+	<parameter name="invoiceType" class="java.lang.String"/>
+	<parameter name="paymentType" class="java.lang.String"/>
+	<parameter name="totalPriceWithVAT" class="java.math.BigDecimal"/>
+	<parameter name="totalPriceVAT" class="java.math.BigDecimal"/>
+	<parameter name="totalPrice" class="java.math.BigDecimal"/>
 	<field name="passQty" class="java.lang.Integer"/>
-	<field name="price" class="java.lang.Double"/>
-	<field name="totalPrice" class="java.lang.Double"/>
-	<field name="totalPriceVAT" class="java.lang.Double"/>
-	<field name="totalPriceWithVAT" class="java.lang.Double"/>
-	<field name="mol" class="java.lang.String"/>
-	<field name="invoiceType" class="java.lang.String"/>
-	<field name="paymentType" class="java.lang.String"/>
+	<field name="price" class="java.math.BigDecimal"/>
+	<field name="totalPrice" class="java.math.BigDecimal"/>
 	<field name="description" class="java.lang.String"/>
+	<field name="idx" class="java.lang.Integer"/>
 	<title>
-		<band height="79">
+		<band height="79" splitType="Stretch">
 			<image>
 				<reportElement x="0" y="0" width="111" height="79"/>
 				<imageExpression class="java.lang.String"><![CDATA["invoice/jprime.png"]]></imageExpression>
@@ -32,25 +34,25 @@
 			<textField>
 				<reportElement x="111" y="0" width="341" height="79"/>
 				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" size="18" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans" size="18"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["jPrime " + $P{jprime.year} + "\nInvoice\n"+$F{invoiceType}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["jPrime " + $P{jprime.year} + "\nInvoice\n"+$P{invoiceType}]]></textFieldExpression>
 			</textField>
 		</band>
 	</title>
-	<detail>
-		<band height="380">
+	<columnHeader>
+		<band height="182" splitType="Stretch">
 			<textField>
 				<reportElement x="0" y="9" width="555" height="21"/>
 				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Invoice No. "+ $F{invoiceNumber}+ " / "+$F{invoiceDate}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["Invoice No. "+ $P{invoiceNumber}+ " / "+$P{invoiceDate}]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="0" y="48" width="259" height="86"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[jPrime Events Ltd.
 Address: Bulgaria, Sofia, Postal Code 1574, r.d. Hristo Smirnenski, bl. 20, entr. B, fl. 6, apt. 20
@@ -62,9 +64,9 @@ IBAN: BG50PIRB74241605596745]]></text>
 			<textField isStretchWithOverflow="true">
 				<reportElement stretchType="RelativeToBandHeight" x="316" y="48" width="239" height="86"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{client}+"\nAddress: "+$F{clientAddress}+"\nEIK: "+$F{clientEIK}+"\nVAT: "+$F{clientVAT}+"\nMOL: "+$F{mol}+"\n"]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA[$P{client}+"\nAddress: "+$P{clientAddress}+"\nEIK: "+$P{clientEIK}+"\nVAT: "+$P{clientVAT}+"\nMOL: "+$P{mol}+"\n"]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="0" y="162" width="23" height="20"/>
@@ -76,12 +78,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[No.]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="23" y="162" width="221" height="20"/>
+				<reportElement x="23" y="162" width="260" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -90,12 +92,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Description]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="244" y="162" width="72" height="20"/>
+				<reportElement x="283" y="162" width="72" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -104,12 +106,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Quantity (pcs.)]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="316" y="162" width="111" height="20"/>
+				<reportElement x="355" y="162" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -118,12 +120,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Price]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="427" y="162" width="128" height="20"/>
+				<reportElement x="452" y="162" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -132,26 +134,16 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Total price]]></text>
 			</staticText>
-			<staticText>
-				<reportElement x="0" y="182" width="23" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[1.]]></text>
-			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="20" splitType="Stretch">
 			<textField isStretchWithOverflow="true">
-				<reportElement x="23" y="182" width="221" height="20"/>
+				<reportElement x="23" y="0" width="260" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -159,13 +151,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Left" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans" size="9"/>
 				</textElement>
 				<textFieldExpression class="java.lang.String"><![CDATA[$F{description}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true">
-				<reportElement x="244" y="182" width="72" height="20"/>
+				<reportElement x="283" y="0" width="72" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -174,12 +166,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{passQty}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.Integer"><![CDATA[$F{passQty}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="true">
-				<reportElement x="316" y="182" width="111" height="20"/>
+				<reportElement x="355" y="0" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -188,12 +180,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" isBold="true" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans" isBold="true"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{price}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{price}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="##0.00">
-				<reportElement x="427" y="182" width="128" height="20"/>
+				<reportElement x="452" y="0" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -201,13 +193,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{totalPrice}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{totalPrice}]]></textFieldExpression>
 			</textField>
-			<staticText>
-				<reportElement x="316" y="202" width="111" height="20"/>
+			<textField>
+				<reportElement x="0" y="0" width="23" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -216,12 +208,44 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.lang.String"><![CDATA[$F{idx} + "."]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="34" splitType="Stretch">
+			<line>
+				<reportElement x="0" y="0" width="555" height="1"/>
+			</line>
+			<staticText>
+				<reportElement x="349" y="14" width="135" height="20"/>
+				<textElement lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[Bulgarian Java User Group]]></text>
+			</staticText>
+		</band>
+	</pageFooter>
+	<summary>
+		<band height="218" splitType="Stretch">
+			<staticText>
+				<reportElement x="355" y="0" width="97" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Total price]]></text>
 			</staticText>
 			<textField pattern="##0.00">
-				<reportElement x="427" y="202" width="128" height="20"/>
+				<reportElement x="452" y="0" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -229,13 +253,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{totalPrice}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPrice}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="316" y="222" width="111" height="20"/>
+				<reportElement x="355" y="20" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -243,13 +267,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[VAT 20%]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="316" y="242" width="111" height="20"/>
+				<reportElement x="355" y="40" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -257,13 +281,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Total price with VAT]]></text>
 			</staticText>
 			<textField pattern="##0.00">
-				<reportElement x="427" y="222" width="128" height="20"/>
+				<reportElement x="452" y="20" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -271,13 +295,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{totalPriceVAT}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPriceVAT}]]></textFieldExpression>
 			</textField>
 			<textField pattern="##0.00">
-				<reportElement x="427" y="242" width="128" height="20"/>
+				<reportElement x="452" y="40" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -285,57 +309,39 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{totalPriceWithVAT}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPriceWithVAT}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="378" y="318" width="177" height="21"/>
+				<reportElement x="378" y="104" width="177" height="21"/>
 				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Sofia,  "+$F{invoiceDate}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["Sofia,  "+$P{invoiceDate}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="11" y="242" width="266" height="20"/>
+				<reportElement x="11" y="40" width="266" height="20"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Payment type: "+$F{paymentType}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["Payment type: "+$P{paymentType}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="11" y="222" width="279" height="20"/>
+				<reportElement x="11" y="20" width="279" height="20"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[All prices are in BGN]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="0" y="339" width="176" height="41"/>
+				<reportElement x="0" y="125" width="176" height="41"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Stamping and signing are not necessary elements according to law]]></text>
 			</staticText>
 		</band>
-	</detail>
-	<pageFooter>
-		<band height="54">
-			<line>
-				<reportElement x="0" y="12" width="555" height="1"/>
-			</line>
-			<staticText>
-				<reportElement x="349" y="26" width="135" height="20"/>
-				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[Bulgarian Java User Group]]></text>
-			</staticText>
-			<image>
-				<reportElement x="0" y="0" width="111" height="54"/>
-				<imageExpression class="java.lang.String"><![CDATA["invoice/sty.png"]]></imageExpression>
-			</image>
-		</band>
-	</pageFooter>
+	</summary>
 </jasperReport>

--- a/src/main/resources/invoice/invoice_company_template_bg.jrxml
+++ b/src/main/resources/invoice/invoice_company_template_bg.jrxml
@@ -4,23 +4,25 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<parameter name="jprime.year" class="java.lang.String" isForPrompting="false"/>
-	<field name="invoiceDate" class="java.lang.String"/>
-	<field name="invoiceNumber" class="java.lang.String"/>
-	<field name="client" class="java.lang.String"/>
-	<field name="clientAddress" class="java.lang.String"/>
-	<field name="clientVAT" class="java.lang.String"/>
-	<field name="clientEIK" class="java.lang.String"/>
+	<parameter name="invoiceDate" class="java.lang.String"/>
+	<parameter name="invoiceNumber" class="java.lang.String"/>
+	<parameter name="client" class="java.lang.String"/>
+	<parameter name="clientAddress" class="java.lang.String"/>
+	<parameter name="clientVAT" class="java.lang.String"/>
+	<parameter name="clientEIK" class="java.lang.String"/>
+	<parameter name="mol" class="java.lang.String"/>
+	<parameter name="invoiceType" class="java.lang.String"/>
+	<parameter name="paymentType" class="java.lang.String"/>
+	<parameter name="totalPriceWithVAT" class="java.math.BigDecimal"/>
+	<parameter name="totalPriceVAT" class="java.math.BigDecimal"/>
+	<parameter name="totalPrice" class="java.math.BigDecimal"/>
 	<field name="passQty" class="java.lang.Integer"/>
-	<field name="price" class="java.lang.Double"/>
-	<field name="totalPrice" class="java.lang.Double"/>
-	<field name="totalPriceVAT" class="java.lang.Double"/>
-	<field name="totalPriceWithVAT" class="java.lang.Double"/>
-	<field name="mol" class="java.lang.String"/>
-	<field name="invoiceType" class="java.lang.String"/>
-	<field name="paymentType" class="java.lang.String"/>
+	<field name="price" class="java.math.BigDecimal"/>
+	<field name="totalPrice" class="java.math.BigDecimal"/>
 	<field name="description" class="java.lang.String"/>
+	<field name="idx" class="java.lang.Integer"/>
 	<title>
-		<band height="79">
+		<band height="79" splitType="Stretch">
 			<image>
 				<reportElement x="0" y="0" width="111" height="79"/>
 				<imageExpression class="java.lang.String"><![CDATA["invoice/jprime.png"]]></imageExpression>
@@ -32,25 +34,25 @@
 			<textField>
 				<reportElement x="111" y="0" width="341" height="79"/>
 				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" size="18" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans" size="18"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["jPrime " + $P{jprime.year} + "\nФактура\n"+$F{invoiceType}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["jPrime " + $P{jprime.year} + "\nФактура\n"+$P{invoiceType}]]></textFieldExpression>
 			</textField>
 		</band>
 	</title>
-	<detail>
-		<band height="380">
+	<columnHeader>
+		<band height="182" splitType="Stretch">
 			<textField>
 				<reportElement x="0" y="9" width="555" height="21"/>
 				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Фактура No. "+ $F{invoiceNumber}+ " / "+$F{invoiceDate}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["Фактура No. "+ $P{invoiceNumber}+ " / "+$P{invoiceDate}]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="0" y="48" width="259" height="86"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[ДжейПрайм Ивентс ООД.
 Адрес: България, 1574 София, ж.к. Христо Смирненски бл. 20, вх. Б. ет. 6, ап. 20
@@ -62,9 +64,9 @@ IBAN: BG50PIRB74241605596745]]></text>
 			<textField isStretchWithOverflow="true">
 				<reportElement x="316" y="48" width="239" height="86"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{client}+"\nАдрес: "+$F{clientAddress}+"\nЕИК: "+$F{clientEIK}+"\nДДС: "+$F{clientVAT}+"\nМОЛ: "+$F{mol}+"\n"]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA[$P{client}+"\nАдрес: "+$P{clientAddress}+"\nЕИК: "+$P{clientEIK}+"\nДДС: "+$P{clientVAT}+"\nМОЛ: "+$P{mol}+"\n"]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="0" y="162" width="23" height="20"/>
@@ -76,12 +78,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[No.]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="23" y="162" width="221" height="20"/>
+				<reportElement x="23" y="162" width="260" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -90,12 +92,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Описание]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="244" y="162" width="72" height="20"/>
+				<reportElement x="283" y="162" width="72" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -104,12 +106,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Количество (бр.)]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="316" y="162" width="111" height="20"/>
+				<reportElement x="355" y="162" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -118,12 +120,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Цена]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="427" y="162" width="128" height="20"/>
+				<reportElement x="452" y="162" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -132,26 +134,16 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Обща цена]]></text>
 			</staticText>
-			<staticText>
-				<reportElement x="0" y="182" width="23" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[1.]]></text>
-			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="20" splitType="Stretch">
 			<textField isStretchWithOverflow="true">
-				<reportElement x="23" y="182" width="221" height="20"/>
+				<reportElement x="23" y="0" width="260" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -159,13 +151,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Left" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans" size="9"/>
 				</textElement>
 				<textFieldExpression class="java.lang.String"><![CDATA[$F{description}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true">
-				<reportElement x="244" y="182" width="72" height="20"/>
+				<reportElement x="283" y="0" width="72" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -174,12 +166,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<textFieldExpression class="java.lang.Integer"><![CDATA[$F{passQty}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="true">
-				<reportElement x="316" y="182" width="111" height="20"/>
+				<reportElement x="355" y="0" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -188,12 +180,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" isBold="true" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans" isBold="true"/>
 				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{price}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{price}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="##0.00">
-				<reportElement x="427" y="182" width="128" height="20"/>
+				<reportElement x="452" y="0" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -201,137 +193,155 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPrice}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="316" y="202" width="111" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[Обща цена]]></text>
-			</staticText>
-			<textField pattern="##0.00">
-				<reportElement x="427" y="202" width="128" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPrice}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="316" y="222" width="111" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[ДДС 20%]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="316" y="242" width="111" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[Обща цена с ДДС]]></text>
-			</staticText>
-			<textField pattern="##0.00">
-				<reportElement x="427" y="222" width="128" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPriceVAT}]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00">
-				<reportElement x="427" y="242" width="128" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPriceWithVAT}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{totalPrice}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="378" y="318" width="177" height="21"/>
-				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<reportElement x="0" y="0" width="23" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["София,  "+$F{invoiceDate}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA[$F{idx} + "."]]></textFieldExpression>
 			</textField>
-			<textField>
-				<reportElement x="11" y="242" width="266" height="20"/>
-				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Тип плащане: "+$F{paymentType}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="11" y="222" width="279" height="20"/>
-				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[Всичките цени са в Български Лева]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="0" y="339" width="176" height="41"/>
-				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[Печат и подпис не са задължителни по закон]]></text>
-			</staticText>
 		</band>
 	</detail>
 	<pageFooter>
-		<band height="54">
+		<band height="34" splitType="Stretch">
 			<line>
-				<reportElement x="0" y="12" width="555" height="1"/>
+				<reportElement x="0" y="0" width="555" height="1"/>
 			</line>
 			<staticText>
-				<reportElement x="349" y="26" width="135" height="20"/>
+				<reportElement x="349" y="14" width="135" height="20"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Bulgarian Java User Group]]></text>
 			</staticText>
 		</band>
 	</pageFooter>
+	<summary>
+		<band height="218" splitType="Stretch">
+			<staticText>
+				<reportElement x="355" y="0" width="97" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[Данъчна основа]]></text>
+			</staticText>
+			<textField pattern="##0.00">
+				<reportElement x="452" y="0" width="103" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPrice}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="355" y="20" width="97" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[ДДС 20%]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="355" y="40" width="97" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[Обща цена с ДДС]]></text>
+			</staticText>
+			<textField pattern="##0.00">
+				<reportElement x="452" y="20" width="103" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPriceVAT}]]></textFieldExpression>
+			</textField>
+			<textField pattern="##0.00">
+				<reportElement x="452" y="40" width="103" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPriceWithVAT}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="378" y="104" width="177" height="21"/>
+				<textElement textAlignment="Center" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.lang.String"><![CDATA["София,  "+$P{invoiceDate}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="11" y="40" width="266" height="20"/>
+				<textElement lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.lang.String"><![CDATA["Тип плащане: "+$P{paymentType}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="11" y="20" width="279" height="20"/>
+				<textElement lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[Всичките цени са в Български Лева]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="0" y="125" width="176" height="41"/>
+				<textElement lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[Печат и подпис не са задължителни по закон]]></text>
+			</staticText>
+		</band>
+	</summary>
 </jasperReport>

--- a/src/main/resources/invoice/invoice_individual_template.jrxml
+++ b/src/main/resources/invoice/invoice_individual_template.jrxml
@@ -4,22 +4,24 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<parameter name="jprime.year" class="java.lang.String" isForPrompting="false"/>
-	<field name="invoiceDate" class="java.lang.String"/>
-	<field name="invoiceNumber" class="java.lang.String"/>
-	<field name="client" class="java.lang.String"/>
-	<field name="clientAddress" class="java.lang.String"/>
-	<field name="clientVAT" class="java.lang.String"/>
-	<field name="clientEIK" class="java.lang.String"/>
+	<parameter name="invoiceDate" class="java.lang.String"/>
+	<parameter name="invoiceNumber" class="java.lang.String"/>
+	<parameter name="client" class="java.lang.String"/>
+	<parameter name="clientAddress" class="java.lang.String"/>
+	<parameter name="clientVAT" class="java.lang.String"/>
+	<parameter name="clientEIK" class="java.lang.String"/>
+	<parameter name="invoiceType" class="java.lang.String"/>
+	<parameter name="paymentType" class="java.lang.String"/>
+	<parameter name="totalPriceWithVAT" class="java.math.BigDecimal"/>
+	<parameter name="totalPriceVAT" class="java.math.BigDecimal"/>
+	<parameter name="totalPrice" class="java.math.BigDecimal"/>
 	<field name="passQty" class="java.lang.Integer"/>
-	<field name="price" class="java.lang.Double"/>
-	<field name="totalPrice" class="java.lang.Double"/>
-	<field name="totalPriceVAT" class="java.lang.Double"/>
-	<field name="totalPriceWithVAT" class="java.lang.Double"/>
-	<field name="paymentType" class="java.lang.String"/>
-	<field name="invoiceType" class="java.lang.String"/>
+	<field name="price" class="java.math.BigDecimal"/>
+	<field name="totalPrice" class="java.math.BigDecimal"/>
 	<field name="description" class="java.lang.String"/>
+	<field name="idx" class="java.lang.Integer"/>
 	<title>
-		<band height="79">
+		<band height="79" splitType="Stretch">
 			<image>
 				<reportElement x="0" y="0" width="111" height="79"/>
 				<imageExpression class="java.lang.String"><![CDATA["invoice/jprime.png"]]></imageExpression>
@@ -31,25 +33,25 @@
 			<textField>
 				<reportElement x="111" y="0" width="341" height="79"/>
 				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" size="18" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans" size="18"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["jPrime " + $P{jprime.year} + "\nInvoice\n"+$F{invoiceType}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["jPrime " + $P{jprime.year} + "\nInvoice\n"+$P{invoiceType}]]></textFieldExpression>
 			</textField>
 		</band>
 	</title>
-	<detail>
-		<band height="380">
+	<columnHeader>
+		<band height="182" splitType="Stretch">
 			<textField>
 				<reportElement x="0" y="9" width="555" height="21"/>
 				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Invoice No. "+ $F{invoiceNumber}+ " / "+$F{invoiceDate}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["Invoice No. "+ $P{invoiceNumber}+ " / "+$P{invoiceDate}]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="0" y="48" width="259" height="86"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[jPrime Events Ltd.
 Address: Bulgaria, Sofia, Postal Code 1574, r.d. Hristo Smirnenski, bl. 20, entr. B, fl. 6, apt. 20
@@ -61,9 +63,9 @@ IBAN: BG50PIRB74241605596745]]></text>
 			<textField isStretchWithOverflow="true">
 				<reportElement x="316" y="48" width="239" height="86"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{client}+"\nEGN: 9999999999"]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA[$P{client}+"\nEGN: 9999999999"]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="0" y="162" width="23" height="20"/>
@@ -75,12 +77,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[No.]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="23" y="162" width="221" height="20"/>
+				<reportElement x="23" y="162" width="260" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -89,12 +91,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Description]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="244" y="162" width="72" height="20"/>
+				<reportElement x="283" y="162" width="72" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -103,12 +105,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Quantity (pcs.)]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="316" y="162" width="111" height="20"/>
+				<reportElement x="355" y="162" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -117,12 +119,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Price]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="427" y="162" width="128" height="20"/>
+				<reportElement x="452" y="162" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -131,26 +133,16 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Total price]]></text>
 			</staticText>
-			<staticText>
-				<reportElement x="0" y="182" width="23" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[1.]]></text>
-			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="20" splitType="Stretch">
 			<textField isStretchWithOverflow="true">
-				<reportElement x="23" y="182" width="221" height="20"/>
+				<reportElement x="23" y="0" width="260" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -158,13 +150,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Left" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans" size="9"/>
 				</textElement>
 				<textFieldExpression class="java.lang.String"><![CDATA[$F{description}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true">
-				<reportElement x="244" y="182" width="72" height="20"/>
+				<reportElement x="283" y="0" width="72" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -173,12 +165,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<textFieldExpression class="java.lang.Integer"><![CDATA[$F{passQty}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="true">
-				<reportElement x="316" y="182" width="111" height="20"/>
+				<reportElement x="355" y="0" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -187,12 +179,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" isBold="true" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans" isBold="true"/>
 				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{price}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{price}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="##0.00">
-				<reportElement x="427" y="182" width="128" height="20"/>
+				<reportElement x="452" y="0" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -200,13 +192,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPrice}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{totalPrice}]]></textFieldExpression>
 			</textField>
-			<staticText>
-				<reportElement x="316" y="202" width="111" height="20"/>
+			<textField>
+				<reportElement x="0" y="0" width="23" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -215,12 +207,44 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.lang.String"><![CDATA[$F{idx} + "."]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="34" splitType="Stretch">
+			<line>
+				<reportElement x="0" y="0" width="555" height="1"/>
+			</line>
+			<staticText>
+				<reportElement x="349" y="14" width="135" height="20"/>
+				<textElement lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[Bulgarian Java User Group]]></text>
+			</staticText>
+		</band>
+	</pageFooter>
+	<summary>
+		<band height="218" splitType="Stretch">
+			<staticText>
+				<reportElement x="355" y="0" width="97" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Total price]]></text>
 			</staticText>
 			<textField pattern="##0.00">
-				<reportElement x="427" y="202" width="128" height="20"/>
+				<reportElement x="452" y="0" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -228,13 +252,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPrice}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPrice}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="316" y="222" width="111" height="20"/>
+				<reportElement x="355" y="20" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -242,13 +266,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[VAT 20%]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="316" y="242" width="111" height="20"/>
+				<reportElement x="355" y="40" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -256,13 +280,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Total price with VAT]]></text>
 			</staticText>
 			<textField pattern="##0.00">
-				<reportElement x="427" y="222" width="128" height="20"/>
+				<reportElement x="452" y="20" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -270,13 +294,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPriceVAT}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPriceVAT}]]></textFieldExpression>
 			</textField>
 			<textField pattern="##0.00">
-				<reportElement x="427" y="242" width="128" height="20"/>
+				<reportElement x="452" y="40" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -284,57 +308,39 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPriceWithVAT}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPriceWithVAT}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="378" y="318" width="177" height="21"/>
+				<reportElement x="378" y="104" width="177" height="21"/>
 				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Sofia,  "+$F{invoiceDate}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["Sofia,  "+$P{invoiceDate}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="23" y="242" width="266" height="20"/>
+				<reportElement x="11" y="40" width="266" height="20"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Payment type: "+$F{paymentType}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["Payment type: "+$P{paymentType}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="23" y="226" width="279" height="16"/>
+				<reportElement x="11" y="20" width="279" height="20"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[All prices are in BGN]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="0" y="339" width="176" height="41"/>
+				<reportElement x="0" y="125" width="176" height="41"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Stamping and signing are not necessary elements according to law]]></text>
 			</staticText>
 		</band>
-	</detail>
-	<pageFooter>
-		<band height="54">
-			<line>
-				<reportElement x="0" y="12" width="555" height="1"/>
-			</line>
-			<staticText>
-				<reportElement x="349" y="26" width="135" height="20"/>
-				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[Bulgarian Java User Group]]></text>
-			</staticText>
-			<image>
-				<reportElement x="0" y="0" width="111" height="54"/>
-				<imageExpression class="java.lang.String"><![CDATA["invoice/sty.png"]]></imageExpression>
-			</image>
-		</band>
-	</pageFooter>
+	</summary>
 </jasperReport>

--- a/src/main/resources/invoice/invoice_individual_template_bg.jrxml
+++ b/src/main/resources/invoice/invoice_individual_template_bg.jrxml
@@ -4,22 +4,24 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<parameter name="jprime.year" class="java.lang.String" isForPrompting="false"/>
-	<field name="invoiceDate" class="java.lang.String"/>
-	<field name="invoiceNumber" class="java.lang.String"/>
-	<field name="client" class="java.lang.String"/>
-	<field name="clientAddress" class="java.lang.String"/>
-	<field name="clientVAT" class="java.lang.String"/>
-	<field name="clientEIK" class="java.lang.String"/>
+	<parameter name="invoiceDate" class="java.lang.String"/>
+	<parameter name="invoiceNumber" class="java.lang.String"/>
+	<parameter name="client" class="java.lang.String"/>
+	<parameter name="clientAddress" class="java.lang.String"/>
+	<parameter name="clientVAT" class="java.lang.String"/>
+	<parameter name="clientEIK" class="java.lang.String"/>
+	<parameter name="invoiceType" class="java.lang.String"/>
+	<parameter name="paymentType" class="java.lang.String"/>
+	<parameter name="totalPriceWithVAT" class="java.math.BigDecimal"/>
+    <parameter name="totalPriceVAT" class="java.math.BigDecimal"/>
+	<parameter name="totalPrice" class="java.math.BigDecimal"/>
 	<field name="passQty" class="java.lang.Integer"/>
-	<field name="price" class="java.lang.Double"/>
-	<field name="totalPrice" class="java.lang.Double"/>
-	<field name="totalPriceVAT" class="java.lang.Double"/>
-	<field name="totalPriceWithVAT" class="java.lang.Double"/>
-	<field name="paymentType" class="java.lang.String"/>
-	<field name="invoiceType" class="java.lang.String"/>
+	<field name="price" class="java.math.BigDecimal"/>
+	<field name="totalPrice" class="java.math.BigDecimal"/>
 	<field name="description" class="java.lang.String"/>
+	<field name="idx" class="java.lang.Integer"/>
 	<title>
-		<band height="79">
+		<band height="79" splitType="Stretch">
 			<image>
 				<reportElement x="0" y="0" width="111" height="79"/>
 				<imageExpression class="java.lang.String"><![CDATA["invoice/jprime.png"]]></imageExpression>
@@ -31,25 +33,25 @@
 			<textField>
 				<reportElement x="111" y="0" width="341" height="79"/>
 				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" size="18" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans" size="18"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["jPrime " + $P{jprime.year} + "\nФактура\n"+$F{invoiceType}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["jPrime " + $P{jprime.year} + "\nФактура\n"+$P{invoiceType}]]></textFieldExpression>
 			</textField>
 		</band>
 	</title>
-	<detail>
-		<band height="380">
+	<columnHeader>
+		<band height="182" splitType="Stretch">
 			<textField>
 				<reportElement x="0" y="9" width="555" height="21"/>
 				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Фактура No. "+ $F{invoiceNumber}+ " / "+$F{invoiceDate}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA["Фактура No. "+ $P{invoiceNumber}+ " / "+$P{invoiceDate}]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="0" y="48" width="259" height="86"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[ДжейПрайм Ивентс ООД.
 Адрес: България, 1574 София, ж.к. Христо Смирненски бл. 20, вх. Б. ет. 6, ап. 20
@@ -61,9 +63,9 @@ IBAN: BG50PIRB74241605596745]]></text>
 			<textField isStretchWithOverflow="true">
 				<reportElement x="316" y="48" width="239" height="86"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{client}+"\nЕГН: 9999999999"]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA[$P{client}+"\nЕГН: 9999999999"]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="0" y="162" width="23" height="20"/>
@@ -75,12 +77,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[No.]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="23" y="162" width="221" height="20"/>
+				<reportElement x="23" y="162" width="260" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -89,12 +91,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Описание]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="244" y="162" width="72" height="20"/>
+				<reportElement x="283" y="162" width="72" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -103,12 +105,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Количество (бр.)]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="316" y="162" width="111" height="20"/>
+				<reportElement x="355" y="162" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -117,12 +119,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Цена]]></text>
 			</staticText>
 			<staticText>
-				<reportElement x="427" y="162" width="128" height="20"/>
+				<reportElement x="452" y="162" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -131,26 +133,16 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Обща цена]]></text>
 			</staticText>
-			<staticText>
-				<reportElement x="0" y="182" width="23" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[1.]]></text>
-			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="20" splitType="Stretch">
 			<textField isStretchWithOverflow="true">
-				<reportElement x="23" y="182" width="221" height="20"/>
+				<reportElement x="23" y="0" width="260" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -158,13 +150,13 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Left" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans" size="9"/>
 				</textElement>
 				<textFieldExpression class="java.lang.String"><![CDATA[$F{description}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true">
-				<reportElement x="244" y="182" width="72" height="20"/>
+				<reportElement x="283" y="0" width="72" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -173,12 +165,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<textFieldExpression class="java.lang.Integer"><![CDATA[$F{passQty}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="true">
-				<reportElement x="316" y="182" width="111" height="20"/>
+				<reportElement x="355" y="0" width="97" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -187,12 +179,12 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" isBold="true" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans" isBold="true"/>
 				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{price}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{price}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="##0.00">
-				<reportElement x="427" y="182" width="128" height="20"/>
+				<reportElement x="452" y="0" width="103" height="20"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -200,137 +192,155 @@ IBAN: BG50PIRB74241605596745]]></text>
 					<bottomPen lineWidth="0.25"/>
 					<rightPen lineWidth="0.25"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPrice}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="316" y="202" width="111" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[Обща цена]]></text>
-			</staticText>
-			<textField pattern="##0.00">
-				<reportElement x="427" y="202" width="128" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPrice}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="316" y="222" width="111" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[ДДС 20%]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="316" y="242" width="111" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[Обща цена с ДДС]]></text>
-			</staticText>
-			<textField pattern="##0.00">
-				<reportElement x="427" y="222" width="128" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPriceVAT}]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00">
-				<reportElement x="427" y="242" width="128" height="20"/>
-				<box>
-					<pen lineWidth="0.25"/>
-					<topPen lineWidth="0.25"/>
-					<leftPen lineWidth="0.25"/>
-					<bottomPen lineWidth="0.25"/>
-					<rightPen lineWidth="0.25"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.Double"><![CDATA[$F{totalPriceWithVAT}]]></textFieldExpression>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{totalPrice}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement x="378" y="318" width="177" height="21"/>
-				<textElement textAlignment="Center" lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+				<reportElement x="0" y="0" width="23" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
 				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["София,  "+$F{invoiceDate}]]></textFieldExpression>
+				<textFieldExpression class="java.lang.String"><![CDATA[$F{idx} + "."]]></textFieldExpression>
 			</textField>
-			<textField>
-				<reportElement x="23" y="242" width="266" height="20"/>
-				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Тип плащане: "+$F{paymentType}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="23" y="226" width="279" height="16"/>
-				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[Всичките цени са в Български Лева]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="0" y="339" width="176" height="41"/>
-				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
-				</textElement>
-				<text><![CDATA[Печат и подпис не са задължителни по закон]]></text>
-			</staticText>
 		</band>
 	</detail>
 	<pageFooter>
-		<band height="54">
+		<band height="34" splitType="Stretch">
 			<line>
-				<reportElement x="0" y="12" width="555" height="1"/>
+				<reportElement x="0" y="0" width="555" height="1"/>
 			</line>
 			<staticText>
-				<reportElement x="349" y="26" width="135" height="20"/>
+				<reportElement x="349" y="14" width="135" height="20"/>
 				<textElement lineSpacing="Single">
-					<font fontName="DejaVu Sans" pdfEncoding="Cp1251" isPdfEmbedded="true"/>
+					<font fontName="DejaVu Sans"/>
 				</textElement>
 				<text><![CDATA[Bulgarian Java User Group]]></text>
 			</staticText>
 		</band>
 	</pageFooter>
+	<summary>
+		<band height="218" splitType="Stretch">
+			<staticText>
+				<reportElement x="355" y="0" width="97" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[Данъчна основа]]></text>
+			</staticText>
+			<textField pattern="##0.00">
+				<reportElement x="452" y="0" width="103" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPrice}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="355" y="20" width="97" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[ДДС 20%]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="355" y="40" width="97" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[Обща цена с ДДС]]></text>
+			</staticText>
+			<textField pattern="##0.00">
+				<reportElement x="452" y="20" width="103" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPriceVAT}]]></textFieldExpression>
+			</textField>
+			<textField pattern="##0.00">
+				<reportElement x="452" y="40" width="103" height="20"/>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="0.25"/>
+					<leftPen lineWidth="0.25"/>
+					<bottomPen lineWidth="0.25"/>
+					<rightPen lineWidth="0.25"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Middle" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$P{totalPriceWithVAT}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="378" y="104" width="177" height="21"/>
+				<textElement textAlignment="Center" lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.lang.String"><![CDATA["София,  "+$P{invoiceDate}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="11" y="40" width="266" height="20"/>
+				<textElement lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<textFieldExpression class="java.lang.String"><![CDATA["Тип плащане: "+$P{paymentType}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="11" y="20" width="279" height="20"/>
+				<textElement lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[Всичките цени са в Български Лева]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="0" y="125" width="176" height="41"/>
+				<textElement lineSpacing="Single">
+					<font fontName="DejaVu Sans"/>
+				</textElement>
+				<text><![CDATA[Печат и подпис не са задължителни по закон]]></text>
+			</staticText>
+		</band>
+	</summary>
 </jasperReport>

--- a/src/main/webapp/admin/invoice/invoiceData.jsp
+++ b/src/main/webapp/admin/invoice/invoiceData.jsp
@@ -34,10 +34,10 @@
         </dl>
         <dl>
             <dt>
-                <label for="totalPriceWithVAT">Total price (VAT included)</label>
+                <label for="singlePriceWithVAT">Single price (VAT included)</label>
             </dt>
             <dd>
-                <form:input readonly="true" path="totalPriceWithVAT"/>
+                <form:input path="singlePriceWithVAT"/>
             </dd>
         </dl>
         <dl>
@@ -74,6 +74,14 @@
         </dl>
         <dl>
             <dt>
+                <label for="description">description</label>
+            </dt>
+            <dd>
+                <form:input path="description"/>
+            </dd>
+        </dl>
+        <dl>
+            <dt>
                 Payment type
             </dt>
             <dd>
@@ -86,29 +94,6 @@
             </dt>
             <dd>
                 <form:input path="invoiceDate"/>
-            </dd>
-        </dl>
-        <dl>
-            <dt><label for="invoiceDetail">Invoice details</label></dt>
-            <dd>
-                <table id="invoiceDetail">
-                    <thead>
-                    <tr>
-                        <th>Description</th>
-                        <th>Pass quantity</th>
-                        <th>Single pass price</th>
-                        <th>total pass price(no VAT)</th>
-                    </tr>
-                    <c:forEach var="detail" items="${invoiceData.invoiceDetails}">
-                        <tr>
-                            <td align="left">${detail.description}</td>
-                            <td align="center">${detail.passQty}</td>
-                            <td align="center">${detail.price}</td>
-                            <td align="center">${detail.totalPrice}</td>
-                        </tr>
-                    </c:forEach>
-                    </thead>
-                </table>
             </dd>
         </dl>
         <sec:csrfInput/>

--- a/src/main/webapp/admin/invoice/invoiceData.jsp
+++ b/src/main/webapp/admin/invoice/invoiceData.jsp
@@ -34,10 +34,10 @@
         </dl>
         <dl>
             <dt>
-                <label for="singlePriceWithVAT">Single price (VAT included)</label>
+                <label for="totalPriceWithVAT">Total price (VAT included)</label>
             </dt>
             <dd>
-                <form:input path="singlePriceWithVAT"/>
+                <form:input readonly="true" path="totalPriceWithVAT"/>
             </dd>
         </dl>
         <dl>
@@ -74,14 +74,6 @@
         </dl>
         <dl>
             <dt>
-                <label for="description">description</label>
-            </dt>
-            <dd>
-                <form:input path="description"/>
-            </dd>
-        </dl>
-        <dl>
-            <dt>
                 Payment type
             </dt>
             <dd>
@@ -96,8 +88,30 @@
                 <form:input path="invoiceDate"/>
             </dd>
         </dl>
+        <dl>
+            <dt><label for="invoiceDetail">Invoice details</label></dt>
+            <dd>
+                <table id="invoiceDetail">
+                    <thead>
+                    <tr>
+                        <th>Description</th>
+                        <th>Pass quantity</th>
+                        <th>Single pass price</th>
+                        <th>total pass price(no VAT)</th>
+                    </tr>
+                    <c:forEach var="detail" items="${invoiceData.invoiceDetails}">
+                        <tr>
+                            <td align="left">${detail.description}</td>
+                            <td align="center">${detail.passQty}</td>
+                            <td align="center">${detail.price}</td>
+                            <td align="center">${detail.totalPrice}</td>
+                        </tr>
+                    </c:forEach>
+                    </thead>
+                </table>
+            </dd>
+        </dl>
         <sec:csrfInput/>
-        <form:hidden path="passQty"/>
         <form:hidden path="paymentType"/>
         <form:hidden path="invoiceNumber"/>
         <form:hidden path="registrantId"/>


### PR DESCRIPTION
Use invoice detail as source for report data.
Invoice data is used to fill report parameters.

Introduce two configuration options that can be used to store copy of failed to send invoices on the local file system.
This is primary used for testing purposes.

Add support for EN/BG language for invoice exporter.
By default all invoices are generated in BG.

Signed-off-by: Doychin Bondzhev <doychin@dsoft-bg.com>