### PR TITLE
Add Jackson JSR310 dependency and JsonIgnore annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/main/java/site/model/Speaker.java
+++ b/src/main/java/site/model/Speaker.java
@@ -120,6 +120,7 @@ public class Speaker extends User {
         return submissions;
     }
 
+    @JsonIgnore
     public List<Submission> getAllSubmissions() {
         return Stream.concat(getSubmissions().stream(), getCoSpeakerSubmissions().stream())
             .sorted(Comparator.comparing(s -> s.getBranch().getYear()))
@@ -185,6 +186,7 @@ public class Speaker extends User {
         return getFirstName() + " " + getLastName();
     }
 
+    @JsonIgnore
     public int getNumberOfSubmissions() {
         return numberOfSubmissions;
     }
@@ -234,6 +236,7 @@ public class Speaker extends User {
         this.featured = featured;
     }
 
+    @JsonIgnore
     public Branch getBranch() {
         return branch;
     }


### PR DESCRIPTION
Added `jackson-datatype-jsr310` dependency to handle Java 8 time module serialization/deserialization. Marked specific methods in `Speaker` class with `@JsonIgnore` to exclude them from JSON serialization, ensuring cleaner and more accurate API responses.