### PR TITLE
Add auditing support to entity models

### DIFF
--- a/src/main/java/site/facade/EntityBaseListener.java
+++ b/src/main/java/site/facade/EntityBaseListener.java
@@ -1,0 +1,34 @@
+package site.facade;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import site.model.EntityBase;
+
+public class EntityBaseListener {
+
+    @PrePersist
+    public void beforeSaveNew(EntityBase entity) {
+        entity.setCreatedDate(LocalDateTime.now());
+        String userName = findUserName();
+        entity.setCreatedBy(userName);
+    }
+
+    @PreUpdate
+    public void beforeUpdate(EntityBase entity) {
+        entity.setLastModifiedDate(LocalDateTime.now());
+        String userName = findUserName();
+        entity.setLastModifiedBy(userName);
+    }
+
+    private static String findUserName() {
+        return SecurityContextHolder.getContext() != null && SecurityContextHolder.getContext()
+            .getAuthentication() != null && SecurityContextHolder.getContext()
+            .getAuthentication()
+            .getName() != null ? SecurityContextHolder.getContext().getAuthentication().getName() : "SYSTEM";
+    }
+}

--- a/src/main/java/site/model/BackgroundJob.java
+++ b/src/main/java/site/model/BackgroundJob.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 
+import org.springframework.format.annotation.DateTimeFormat;
+
 @Entity
 public class BackgroundJob {
 
@@ -24,6 +26,7 @@ public class BackgroundJob {
     @Column(columnDefinition = "LONGTEXT")
     private String log;
 
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime completed;
 
     public BackgroundJob(String jobId) {

--- a/src/main/java/site/model/EntityBase.java
+++ b/src/main/java/site/model/EntityBase.java
@@ -3,21 +3,32 @@ package site.model;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import site.facade.EntityBaseListener;
+
 @MappedSuperclass
+@EntityListeners(EntityBaseListener.class)
 public class EntityBase implements java.io.Serializable {
 
     @Column(name = "created_by")
     private String createdBy;
 
     @Column(name = "created_date")
+    @JsonIgnore
+    @DateTimeFormat(pattern = "dd.MM.yyyy HH:mm")
     private LocalDateTime createdDate;
 
     @Column(name = "last_modified_by")
     private String lastModifiedBy;
 
     @Column(name = "last_modified_date")
+    @JsonIgnore
+    @DateTimeFormat(pattern = "dd.MM.yyyy HH:mm")
     private LocalDateTime lastModifiedDate;
 
     public String getCreatedBy() {


### PR DESCRIPTION
Introduce `EntityBaseListener` to set audit fields (`createdBy`, `createdDate`, `lastModifiedBy`, `lastModifiedDate`) using `@PrePersist` and `@PreUpdate` callbacks. Apply Jackson and Spring `@DateTimeFormat` annotations for standardized date handling. Update `BackgroundJob` and `EntityBase` models to support these changes.