### PR TITLE
Add @Param annotation for branch parameter in queries

### DIFF
--- a/src/main/java/site/repository/SpeakerRepository.java
+++ b/src/main/java/site/repository/SpeakerRepository.java
@@ -33,9 +33,9 @@ public interface SpeakerRepository extends JpaRepository<Speaker, Long> {
 
     @Query("SELECT distinct s FROM Speaker s left join s.submissions sub left join s.coSpeakerSubmissions as coSub " +
         "WHERE sub.branch = :branch or coSub.branch = :branch")
-    Page<Speaker> findAllByBranch(Pageable pageable, Branch branch);
+    Page<Speaker> findAllByBranch(Pageable pageable, @Param("branch")Branch branch);
 
     @Query("SELECT distinct s FROM Speaker s left join s.submissions sub left join s.coSpeakerSubmissions as coSub " +
         "WHERE (sub.branch = :branch and sub.status = 'ACCEPTED') or (coSub.branch = :branch and coSub.status = 'ACCEPTED')")
-    Optional<Speaker> findAcceptedSpeaker(Long id, Branch currentBranch);
+    Optional<Speaker> findAcceptedSpeaker(Long id, @Param("branch")Branch branch);
 }


### PR DESCRIPTION
The @Param annotation ensures proper parameter binding in JPA queries. This fixes potential issues with parameter mapping and improves query reliability.