### PR TITLE
Refactor speaker validation and update logic.

### DIFF
--- a/src/main/java/site/controller/AbstractCfpController.java
+++ b/src/main/java/site/controller/AbstractCfpController.java
@@ -1,17 +1,24 @@
 package site.controller;
 
 import java.util.Arrays;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import jakarta.mail.MessagingException;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.multipart.MultipartFile;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
@@ -46,6 +53,39 @@ public class AbstractCfpController {
     @Autowired
     private ThumbnailService thumbnailService;
 
+    /**
+     * Copies data from the submissionSpeaker object to the speaker object if the respective fields in
+     * submissionSpeaker are not empty or blank.
+     *
+     * @param speaker           the Speaker object to which data will be copied
+     * @param submissionSpeaker the Speaker object from which data will be copied
+     */
+    private static void copyDataFromSubmission(Speaker speaker, Speaker submissionSpeaker) {
+        if (ArrayUtils.isNotEmpty(submissionSpeaker.getPicture())) {
+            speaker.setPicture(submissionSpeaker.getPicture());
+        }
+
+        if (StringUtils.isNotBlank(submissionSpeaker.getBio())) {
+            speaker.setBio(submissionSpeaker.getBio());
+        }
+
+        if (StringUtils.isNotBlank(submissionSpeaker.getTwitter())) {
+            speaker.setTwitter(submissionSpeaker.getTwitter());
+        }
+
+        if (StringUtils.isNotBlank(submissionSpeaker.getFirstName())) {
+            speaker.setFirstName(submissionSpeaker.getFirstName());
+        }
+
+        if (StringUtils.isNotBlank(submissionSpeaker.getLastName())) {
+            speaker.setLastName(submissionSpeaker.getLastName());
+        }
+
+        if (StringUtils.isNotBlank(submissionSpeaker.getBsky())) {
+            speaker.setBsky(submissionSpeaker.getBsky());
+        }
+    }
+
     protected void updateCfpModel(Model model, Submission submission) {
         model.addAttribute("submission", submission);
         model.addAttribute("levels", SessionLevel.values());
@@ -68,7 +108,7 @@ public class AbstractCfpController {
 
     protected boolean hasCoSpeaker(Submission submission) {
         return submission.getCoSpeaker() != null && !StringUtils.isEmpty(
-            submission.getCoSpeaker().getLastName());
+            submission.getCoSpeaker().getEmail());
     }
 
     private Speaker handleSubmittedSpeaker(Speaker speaker, MultipartFile image) {
@@ -124,4 +164,60 @@ public class AbstractCfpController {
         return templateEngine.process(templateName, context);
     }
 
+    protected String validateAndUpdateSpeaker(BindingResult bindingResult,
+        Speaker speaker, String role, Consumer<Speaker> speakerUpdate, Supplier<String> onError) {
+        String result = validateEmail(bindingResult, speaker.getEmail(), role, onError);
+        if (result != null) {
+            return result;
+        }
+
+        Speaker existingSpeaker = userFacade.findSpeaker(speaker);
+        if (existingSpeaker != null) {
+            copyDataFromSubmission(existingSpeaker, speaker);
+            speakerUpdate.accept(existingSpeaker);
+        } else {
+            result = validateSpeaker(speaker, bindingResult, role, onError);
+            return result;
+        }
+
+        return null;
+    }
+
+    private String validateSpeaker(Speaker speaker, BindingResult bindingResult, String role,
+        Supplier<String> errorSupplier) {
+        String msg;
+        String field;
+        if (StringUtils.isBlank(speaker.getFirstName())) {
+            msg = "First name is required!";
+            field = "firstName";
+        } else {
+            if (StringUtils.isBlank(speaker.getLastName())) {
+                msg = "Last name is required!";
+                field = "lastName";
+            } else {
+                msg = StringUtils.isEmpty(speaker.getBio()) ? "Bio is required!" : null;
+                field = "bio";
+            }
+        }
+
+        if (msg == null) {
+            return null;
+        }
+        bindingResult.addError(new FieldError("submission", role + "." + field, msg));
+
+        return errorSupplier.get();
+    }
+
+    private String validateEmail(BindingResult bindingResult, String email, String role,
+        Supplier<String> errorSupplier) {
+        EmailValidator emailValidator = new EmailValidator();
+
+        if (!StringUtils.isEmpty(email) && emailValidator.isValid(email, null)) {
+            // Email is valid
+            return null;
+        }
+
+        bindingResult.addError(new FieldError("submission", role + ".email", "Invalid Email!"));
+        return errorSupplier.get();
+    }
 }


### PR DESCRIPTION
Moved common speaker validation and update logic to `AbstractCfpController`. Simplified `CfpController` and `SubmissionController` by delegating repetitive tasks for email validation, speaker updates, and error handling to new reusable methods.