### PR TITLE
Add docker-compose with MariaDB and Adminer services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+
+  db:
+    image: mariadb
+    restart: always
+    environment:
+      MARIADB_ROOT_PASSWORD: admin
+    ports:
+      - 3306:3306
+    volumes:
+      - ./mysql:/var/lib/mysql
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8180:8080


### PR DESCRIPTION
Introduce a `docker-compose.yml` file to set up MariaDB and Adminer. This configuration simplifies database management and testing by providing a ready-to-use local environment. MariaDB is exposed on port 3306, and Adminer on port 8180.

This can be used to host local mariadb instance for testing purposes.