### PR TITLE
Remove unused hidden field from CFP form tag

### DIFF
--- a/src/main/webapp/WEB-INF/tags/user/cfp.tag
+++ b/src/main/webapp/WEB-INF/tags/user/cfp.tag
@@ -98,7 +98,6 @@
         <form:hidden path="createdDate"/>
         <form:hidden path="createdBy"/>
         <form:hidden path="speaker.id" />
-        <form:hidden path="path"/>
         <c:if test="${!admin}">
             <p>
                 <c:url var="captchaUrl" value="/captcha-image"/>


### PR DESCRIPTION
The `path` hidden field was removed as it is no longer used. This change helps clean up unnecessary code and improves maintainability. No functional impact is expected.