### PR TITLE
Use readonly attribute instead of disabled for status input. 

### DIFF
--- a/src/main/java/site/controller/AdminSessionController.java
+++ b/src/main/java/site/controller/AdminSessionController.java
@@ -68,7 +68,7 @@ public class AdminSessionController {
         if (!"".equals(id)) {
             session = adminFacade.findOneSession(Long.parseLong(id));
         }
-        
+
         if (!isEmpty(title)) {
             session.setTitle(title);
             session.setSubmission(null);
@@ -101,17 +101,17 @@ public class AdminSessionController {
         model.addAttribute("session", session);
 
         // Reduce the list of submissions to only with those that are not scheduled yet
-        List<Submission> acceptedSubmissions =
+        List<Submission> confirmedSubmissions =
             adminFacade.findAllConfirmedSubmissionsForBranch(branchService.getCurrentBranch());
         List<Submission> scheduledSubmissions =
             adminFacade.findAllSessions().stream().map(Session::getSubmission).toList();
-        acceptedSubmissions = acceptedSubmissions.stream()
+        confirmedSubmissions = confirmedSubmissions.stream()
                                                  .filter(
                                                      submission -> !scheduledSubmissions.contains(submission))
                                                  .collect(Collectors.toList());
         if (session.getSubmission() != null) {
             // For edit - we need to have current submission to
-            acceptedSubmissions.add(session.getSubmission());
+            confirmedSubmissions.add(session.getSubmission());
         } else {
             if (!StringUtils.isEmpty(session.getTitle())) {
                 Submission submission =
@@ -125,7 +125,7 @@ public class AdminSessionController {
             }
         }
 
-        model.addAttribute("submissions", acceptedSubmissions);
+        model.addAttribute("submissions", confirmedSubmissions);
         model.addAttribute("halls", adminFacade.findAllVenueHalls());
 
         return SESSIONS_EDIT_JSP;

--- a/src/main/webapp/WEB-INF/tags/user/cfp.tag
+++ b/src/main/webapp/WEB-INF/tags/user/cfp.tag
@@ -73,7 +73,7 @@
                     <label for="status">status</label>
                 </dt>
                 <dd>
-                    <form:input path="status" disabled="true"/>
+                    <form:input path="status" readonly="true"/>
                 </dd>
             </dl>
             <dl>


### PR DESCRIPTION
Updated the status input field to use `readonly` instead of `disabled`. This change ensures that the field value is still submitted with the form while preventing user edits.